### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/PraveenKalavai/8ce9edf7-1073-4420-bf10-cccc072cad8c/ad5c94ca-9668-45ac-86e2-70303ef9b99e/_apis/work/boardbadge/bcc89f6b-b5ee-4358-9406-ea0c23d2989d)](https://dev.azure.com/PraveenKalavai/8ce9edf7-1073-4420-bf10-cccc072cad8c/_boards/board/t/ad5c94ca-9668-45ac-86e2-70303ef9b99e/Microsoft.RequirementCategory)
 - 👋 Hi, I’m @prvnkalavai
 - 👀 I’m interested in ... DevOps, DIY Projects, stocks & investments, automation, Financial Independence, Badminton
 - 🌱 I’m currently learning ... DevOps


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/PraveenKalavai/8ce9edf7-1073-4420-bf10-cccc072cad8c/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.